### PR TITLE
Update sinon-qunit.js

### DIFF
--- a/lib/sinon-qunit.js
+++ b/lib/sinon-qunit.js
@@ -18,12 +18,7 @@ sinon.config = {
 (function (global) {
     var qTest = QUnit.test;
     
-    QUnit.test = global.test = function (testName, expected, callback, async) {
-        if (arguments.length === 2) {
-            callback = expected;
-            expected = null;
-        }
-
-        return qTest(testName, expected, sinon.test(callback), async);
+    QUnit.test = global.test = function (testName, callback, async) {
+        return qTest(testName, sinon.test(callback), async);
     };
 }(this));


### PR DESCRIPTION
QUnit.test no longer has an 'expected' parameter (version 2.0.1).  Leads to ".callback is null" errors.